### PR TITLE
Correctly detect a daily Cron and show the Daily tab

### DIFF
--- a/src/app/cron-editor/cron-editor.component.ts
+++ b/src/app/cron-editor/cron-editor.component.ts
@@ -420,11 +420,11 @@ export class CronGenComponent implements OnInit, OnChanges {
       this.state.hourly.hours = parseInt(hours.substring(2));
       this.state.hourly.minutes = parseInt(minutes);
       this.state.hourly.seconds = parseInt(seconds);
-    } else if (cron.match(/\d+ \d+ \d+ 1\/\d+ \* [\?\*] \*/)) {
+    } else if (cron.match(/\d+ \d+ \d+ 1\/\d+ \* [\?\*] \*/) || cron.match(/\d+ \d+ \d+ \* \* [\?\*] \*/)) {
       this.activeTab = 'daily';
 
       this.state.daily.subTab = 'everyDays';
-      this.state.daily.everyDays.days = parseInt(dayOfMonth.substring(2));
+      this.state.daily.everyDays.days = (dayOfMonth === '*') ? 1 : parseInt(dayOfMonth.substring(2));
       const parsedHours = parseInt(hours);
       this.state.daily.everyDays.hours = this.getAmPmHour(parsedHours);
       this.state.daily.everyDays.hourType = this.getHourType(parsedHours);


### PR DESCRIPTION
**Issue:**
Creating a daily Cron then making it the default expression pre-selects the "Advanced" tab instead of the "Daily" tab. This is an issue when persisting an expression then revisiting it to change/review it.

**Reproducible steps:**
On the Daily tab, create a Cron that will run every 1 day(s) at any specific time. Take the resulting expression and set it as the component's default expression.

**Notes:**
It seems the code that normalises the expression converts;

30 6 1/1 * * => 30 6 * * *

The changes in this PR handle this situation and shows the "Default" tab.