### PR TITLE
Import CommonModule instead of BrowserModule because BrowserModule wa…

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import {BrowserModule} from '@angular/platform-browser';
+import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
@@ -10,7 +10,7 @@ import {APP_BASE_HREF} from '@angular/common';
 
 @NgModule({
   imports: [
-    BrowserModule,
+    CommonModule,
     FormsModule,
     RouterModule.forRoot([]),
     CronEditorModule


### PR DESCRIPTION
A potential fix for 
"BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor from a lazy-loaded module, import `CommonModule` instead."
error i was getting when integrating your package