### PR TITLE
Scheduler resets to default of 1 hour when making changes to a job

### DIFF
--- a/src/app/cron-editor/cron-editor.component.ts
+++ b/src/app/cron-editor/cron-editor.component.ts
@@ -415,11 +415,13 @@ export class CronGenComponent implements OnInit, OnChanges {
       this.state.minutes.minutes = parseInt(minutes.substring(2));
       this.state.minutes.seconds = parseInt(seconds);
     } else if (cron.match(/\d+ \d+ 0\/\d+ 1\/1 \* [\?\*] \*/)) {
-      this.activeTab = 'hourly';
-
+      
       this.state.hourly.hours = parseInt(hours.substring(2));
       this.state.hourly.minutes = parseInt(minutes);
       this.state.hourly.seconds = parseInt(seconds);
+      
+      this.activeTab = 'hourly';
+
     } else if (cron.match(/\d+ \d+ \d+ 1\/\d+ \* [\?\*] \*/)) {
       this.activeTab = 'daily';
 

--- a/src/app/cron-editor/cron-editor.component.ts
+++ b/src/app/cron-editor/cron-editor.component.ts
@@ -415,7 +415,6 @@ export class CronGenComponent implements OnInit, OnChanges {
       this.state.minutes.minutes = parseInt(minutes.substring(2));
       this.state.minutes.seconds = parseInt(seconds);
     } else if (cron.match(/\d+ \d+ 0\/\d+ 1\/1 \* [\?\*] \*/)) {
-      
       this.state.hourly.hours = parseInt(hours.substring(2));
       this.state.hourly.minutes = parseInt(minutes);
       this.state.hourly.seconds = parseInt(seconds);


### PR DESCRIPTION
This is a fix for hourly scheduler where cron expression set to 1 hour by default while advanced tab is hide and scheduler is set to some hours. Due to this bug while editing other configurations of job, cron consider 1 hour as a changed frequency. 